### PR TITLE
[PKG-3142]Fixing pandas dep.  Bumping build number.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,8 +18,7 @@ source:
   sha256: d81970d5811e9c281848f6709a7c66133e58cc0ecb9f46041609f3456122d198
 
 build:
-  number: 0
-  # trigger: 1
+  number: 1
   entry_points:
     - orange-canvas = Orange.canvas.__main__:main
   osx_is_app: true
@@ -58,7 +57,7 @@ requirements:
     - opentsne >=0.6.1,!=0.7.0
     - orange-canvas-core >=0.1.28,<0.2a
     - orange-widget-base >=4.19.0
-    - pandas >=1.3.0,!=1.5.0
+    - pandas >=1.3.0,!=1.5.0,<2.1
     - pip >=18.0
     - pygments >=2.8.0
     - pyqtgraph >=0.12.2,!=0.12.4


### PR DESCRIPTION
- Bumped build number
- Added higher dependency constraint to pandas.
- See upstream issue: https://github.com/biolab/orange3/issues/6565#issuecomment-1704372034