### PR TITLE
Update Orange3 to 3.36.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/url-normalize-feedstock/pr2/ca85677
+  - https://staging.continuum.io/prefect/fs/requests-cache-feedstock/pr2/7b8c1e1
+  - https://staging.continuum.io/prefect/fs/orange-canvas-core-feedstock/pr3/5281936
+  - https://staging.continuum.io/prefect/fs/orange-widget-base-feedstock/pr3/4fcfd0f
+  - https://staging.continuum.io/prefect/fs/xgboost-feedstock/pr12/b27e294

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/url-normalize-feedstock/pr2/ca85677
-  - https://staging.continuum.io/prefect/fs/requests-cache-feedstock/pr2/7b8c1e1
-  - https://staging.continuum.io/prefect/fs/orange-canvas-core-feedstock/pr3/5281936
-  - https://staging.continuum.io/prefect/fs/orange-widget-base-feedstock/pr3/4fcfd0f
-  - https://staging.continuum.io/prefect/fs/xgboost-feedstock/pr12/b27e294

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -98,6 +98,7 @@ app:
   entry: orange-canvas
   summary: data visualization and data analysis tool
   icon: icon_48x48.png
+  type: desk
 about:
   home: https://orangedatamining.com/
   summary: Orange, a component-based data mining framework.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,50 +30,46 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
-    - cython
-    - numpy
     - pip
-    - setuptools
-    - wheel
     - python
+    - cython
+    - docutils
+    - numpy
     - recommonmark
-    - sphinx >=4.2.0
-    - docutils <0.17  # docutils changed html template in 0.17
+    - setuptools
+    - sphinx
+    - wheel
   run:
-    # appnope should be in orange-widget-base
-    - appnope  # [osx]
-    - anyqt >=0.1.0
+    - anyqt >=0.2.0
     - baycomp >=1.0.2
     - bottleneck >=1.3.4
+    - catboost >=1.0.1
     - chardet >=3.0.2
-    - httpx >=0.21
-    - joblib >=0.11
+    - httpx >=0.21.0
+    - joblib >=1.0.0
     - keyring
     - keyrings.alt
     - matplotlib-base >=3.2.0
     - networkx
-    - numpy >=1.19.5
+    - numpy >=1.20.0
     - openpyxl
     - opentsne >=0.6.1,!=0.7.0
-    - orange-canvas-core >=0.1.28,<0.2a
-    - orange-widget-base >=4.19.0
-    - pandas >=1.3.0,!=1.5.0
+    - orange-canvas-core >=0.1.30,<0.2a
+    - orange-widget-base >=4.22.0
+    - pandas >=1.4.0,!=1.5.0,!=2.0.0
     - pip >=18.0
     - pygments >=2.8.0
-    - pyqtgraph >=0.12.2,!=0.12.4
+    - pyqtgraph >=0.13.1
     - python
     - python-louvain >=0.13
     - pyyaml
     - qtconsole >=4.7.2
     - requests
-    - scikit-learn >=1.0.1,<1.2.0
+    - scikit-learn >=1.1.0,!=1.2.*,<1.4
     - scipy >=1.9
     - serverfiles
-    - setuptools >=41.0.0
-    # xgboost is optional since user must install libomp (with brew) on macOS for xgboost to work
-    # it is not required for xgboost from conda - it is why I am adding a package to the recipe
-    - xgboost
-    - catboost !=1.0.0  # [not linux or x86_64]
+    - setuptools >=51.0.0
+    - xgboost >=1.7.4
     - xlrd >=1.2.0
     - xlsxwriter
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -83,6 +83,7 @@ test:
     - Orange
     - Orange.canvas
   commands:
+    - pip check
     # - python -c "import pkg_resources; pkg_resources.require('Orange3')"
     - orange-canvas --help
     - export QT_QPA_PLATFORM=offscreen  # [not win]
@@ -98,7 +99,7 @@ app:
   summary: data visualization and data analysis tool
   icon: icon_48x48.png
 about:
-  home: https://orange.biolab.si/
+  home: https://orangedatamining.com/
   summary: Orange, a component-based data mining framework.
   license: GPL-3.0-or-later
   license_family: GPL
@@ -107,7 +108,7 @@ about:
   description: |
     Open source data visualization and data analysis for novice and expert.
     Interactive workflows with a large toolbox.
-  doc_url: https://orange.biolab.si/docs/
+  doc_url: https://orangedatamining.com/docs
   dev_url: https://github.com/biolab/orange3
 
 extra:
@@ -116,5 +117,3 @@ extra:
     - ales-erjavec
     - markotoplak
     - primozgodec
-  skip-lints:
-    - duplicate_key_in_meta_yaml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "Orange3" %}
-{% set version = "3.34.0" %}
+{% set version = "3.36.2" %}
 
 # on our linux builders there is no X11 installed and therefore import
 # test will fail
@@ -15,11 +15,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/Orange3-{{ version }}.tar.gz
-  sha256: d81970d5811e9c281848f6709a7c66133e58cc0ecb9f46041609f3456122d198
+  sha256: d436bb98d33aa6ea7b6083359032c704da1a6a0e656c068ce806e2a3f319af8c
 
 build:
   number: 0
-  # trigger: 1
   entry_points:
     - orange-canvas = Orange.canvas.__main__:main
   osx_is_app: true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ requirements:
   host:
     - pip
     - python
-    - cython
+    - cython >=3.0
     - docutils
     - numpy
     - recommonmark

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,8 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/Orange3-{{ version }}.tar.gz
   sha256: d436bb98d33aa6ea7b6083359032c704da1a6a0e656c068ce806e2a3f319af8c
+  patches:
+    - patches/0001-setup.py-Replace-use-of-imp-module.patch
 
 build:
   number: 0
@@ -29,6 +31,8 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - patch   # [not win]
+    - m2-patch    # [win]
   host:
     - pip
     - python

--- a/recipe/patches/0001-setup.py-Replace-use-of-imp-module.patch
+++ b/recipe/patches/0001-setup.py-Replace-use-of-imp-module.patch
@@ -1,0 +1,30 @@
+From 2b1558a1705664c3c456bbaf0c3408a6744c461b Mon Sep 17 00:00:00 2001
+From: Ales Erjavec <ales.erjavec@fri.uni-lj.si>
+Date: Fri, 22 Dec 2023 10:39:23 +0100
+Subject: [PATCH] setup.py: Replace use of imp module
+
+---
+ setup.py | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index 230c3f2de..a00d449d5 100755
+--- a/setup.py
++++ b/setup.py
+@@ -163,8 +163,12 @@ if not release:
+         GIT_REVISION = git_version()
+     elif os.path.exists('Orange/version.py'):
+         # must be a source distribution, use existing version file
+-        import imp
+-        version = imp.load_source("Orange.version", "Orange/version.py")
++        import importlib.util
++        spec = importlib.util.spec_from_file_location(
++            "Orange.version", filename
++        )
++        version = importlib.util.module_from_spec(spec)
++        spec.loader.exec_module(version)
+         GIT_REVISION = version.git_revision
+     else:
+         GIT_REVISION = "Unknown"
+--
+2.32.1 (Apple Git-133)


### PR DESCRIPTION
orange3 3.36.2

**Destination channel:** {defaults}

### Links

- [PKG-4174](https://anaconda.atlassian.net/browse/PKG-4174) 
- [Upstream repository](https://github.com/biolab/orange3/blob/3.36.2)
- Relevant dependency PRs:
  - `url-normalize` > `requests-cache` > `orange-canvas-core` > `orange-widget-base` > `orange3`
  - `xgboost` > `orange3`

### Explanation of changes:
- Updated `version` and `hash`
- Updated dependencies
- Added patch to replace `imp` module with `importlib`
- Updated redirecting urls
- Added `pip check`
- Added abs.yaml to be removed PRIOR to merge

[PKG-4174]: https://anaconda.atlassian.net/browse/PKG-4174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ